### PR TITLE
QName serialization issue fixed

### DIFF
--- a/src/main/java/org/dom4j/QName.java
+++ b/src/main/java/org/dom4j/QName.java
@@ -229,20 +229,20 @@ public class QName implements Serializable {
     }
 
     private void writeObject(ObjectOutputStream out) throws IOException {
+        out.defaultWriteObject();
+        
         // We use writeObject() and not writeUTF() to minimize space
         // This allows for writing pointers to already written strings
         out.writeObject(namespace.getPrefix());
         out.writeObject(namespace.getURI());
-
-        out.defaultWriteObject();
     }
 
     private void readObject(ObjectInputStream in) throws IOException,
             ClassNotFoundException {
+        in.defaultReadObject();
+        
         String prefix = (String) in.readObject();
         String uri = (String) in.readObject();
-
-        in.defaultReadObject();
 
         namespace = Namespace.get(prefix, uri);
     }


### PR DESCRIPTION
Fixed java.io.NotActiveException: writeFields() may only be called when the fields have not yet been written

Based on issue with dom4j 1.6.1 on JBoss EAP 6+, see http://stackoverflow.com/questions/28740888/cant-serialize-org-dom4j-document-using-jboss-marshalling-api
