### PR TITLE
Xpp fixes

### DIFF
--- a/src/main/java/org/dom4j/xpp/ProxyXmlStartTag.java
+++ b/src/main/java/org/dom4j/xpp/ProxyXmlStartTag.java
@@ -235,6 +235,19 @@ public class ProxyXmlStartTag implements XmlStartTag {
         return false;
     }
 
+    public boolean removeAttributeByRawName(String rawName) throws XmlPullParserException {
+        if (element != null) {
+            for (Iterator<Attribute> iter = element.attributeIterator(); iter.hasNext();) {
+                Attribute attribute = iter.next();
+
+                if (rawName.equals(attribute.getQualifiedName())) {
+                    return element.remove(attribute);
+                }
+            }
+        }
+        return false;
+    }
+
     public String getLocalName() {
         return element.getName();
     }

--- a/src/main/java/org/dom4j/xpp/ProxyXmlStartTag.java
+++ b/src/main/java/org/dom4j/xpp/ProxyXmlStartTag.java
@@ -211,7 +211,7 @@ public class ProxyXmlStartTag implements XmlStartTag {
      * @throws XmlPullParserException
      *             DOCUMENT ME!
      */
-    public void removeAtttributes() throws XmlPullParserException {
+    public void removeAttributes() throws XmlPullParserException {
         if (element != null) {
             element.setAttributes(new ArrayList());
 

--- a/src/main/java/org/dom4j/xpp/ProxyXmlStartTag.java
+++ b/src/main/java/org/dom4j/xpp/ProxyXmlStartTag.java
@@ -221,6 +221,20 @@ public class ProxyXmlStartTag implements XmlStartTag {
         }
     }
 
+    public boolean removeAttributeByName(String namespaceURI, String localName) throws XmlPullParserException {
+        if (element != null) {
+            for (Iterator<Attribute> iter = element.attributeIterator(); iter.hasNext();) {
+                Attribute attribute = iter.next();
+
+                if (namespaceURI.equals(attribute.getNamespaceURI())
+                        && localName.equals(attribute.getName())) {
+                    return element.remove(attribute);
+                }
+            }
+        }
+        return false;
+    }
+
     public String getLocalName() {
         return element.getName();
     }


### PR DESCRIPTION
Fixes a few issues with xpp. Ran into several abstract methods not implemented from XmlStartTag in ProxyXmlStartTag. Renamed removeAtttributes -> removeAttributes. Implemented missing removeAttributeByName and removeAttributeByRawName. This PR fixes those issues and allows it to compile.

