### PR TITLE
Correct work with weak references in QNameCache

### DIFF
--- a/src/main/java/org/dom4j/tree/QNameCache.java
+++ b/src/main/java/org/dom4j/tree/QNameCache.java
@@ -81,7 +81,7 @@ public class QNameCache {
         if (answer == null) {
             answer = createQName(name);
             answer.setDocumentFactory(documentFactory);
-            noNamespaceCache.put(name, answer);
+            noNamespaceCache.put(new String(name.getBytes()), answer);
         }
 
         return answer;
@@ -110,7 +110,7 @@ public class QNameCache {
         if (answer == null) {
             answer = createQName(name, namespace);
             answer.setDocumentFactory(documentFactory);
-            cache.put(name, answer);
+            cache.put(new String(name.getBytes()), answer);
         }
 
         return answer;
@@ -141,7 +141,7 @@ public class QNameCache {
         if (answer == null) {
             answer = createQName(localName, namespace, qName);
             answer.setDocumentFactory(documentFactory);
-            cache.put(localName, answer);
+            cache.put(new String(localName.getBytes()), answer);
         }
 
         return answer;

--- a/src/main/java/org/dom4j/tree/QNameCache.java
+++ b/src/main/java/org/dom4j/tree/QNameCache.java
@@ -81,7 +81,7 @@ public class QNameCache {
         if (answer == null) {
             answer = createQName(name);
             answer.setDocumentFactory(documentFactory);
-            noNamespaceCache.put(new String(name.getBytes()), answer);
+            noNamespaceCache.put(new String(name), answer);
         }
 
         return answer;
@@ -110,7 +110,7 @@ public class QNameCache {
         if (answer == null) {
             answer = createQName(name, namespace);
             answer.setDocumentFactory(documentFactory);
-            cache.put(new String(name.getBytes()), answer);
+            cache.put(new String(name), answer);
         }
 
         return answer;
@@ -141,7 +141,7 @@ public class QNameCache {
         if (answer == null) {
             answer = createQName(localName, namespace, qName);
             answer.setDocumentFactory(documentFactory);
-            cache.put(new String(localName.getBytes()), answer);
+            cache.put(new String(localName), answer);
         }
 
         return answer;


### PR DESCRIPTION
Quote from WeakHashMap's javadoc:
> The value objects in a WeakHashMap are held by ordinary strong references. Thus care should be taken to ensure that **value objects do not strongly refer to their own keys**, either directly or indirectly, since that will prevent the keys from being discarded.

So the current code leads to memory leaks in case of big amount different qnames because it's name (key) is used in QName. My experience - about 1 GB of uncollected garbage for 2 days in production. 

This behaviour is reproduced in https://gist.github.com/skel-nl/291abe36aed9a90f9313f9129b4fbd10
Example with fix like in this pull request - https://gist.github.com/skel-nl/4d33f76d0135fee3cb9452b524341a1e

Another way to fix that - use values as weak references, but in that case values could be discarded but their keys could be or not. Example - https://gist.github.com/skel-nl/1768180608ed7a24f8f28c8de8792ff8