### PR TITLE
Use Correct License Name "Plexus"

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2001-2016 (C) MetaStuff, Ltd. and DOM4J contributors. All Rights Reserved.
+Copyright 2001-2023 © MetaStuff, Ltd. and DOM4J contributors. All Rights Reserved.
 
 Redistribution and use of this software and associated documentation
 ("Software"), with or without modification, are permitted provided
@@ -7,24 +7,24 @@ that the following conditions are met:
 1. Redistributions of source code must retain copyright
    statements and notices.  Redistributions must also contain a
    copy of this document.
- 
+
 2. Redistributions in binary form must reproduce the
    above copyright notice, this list of conditions and the
    following disclaimer in the documentation and/or other
    materials provided with the distribution.
- 
+
 3. The name "DOM4J" must not be used to endorse or promote
    products derived from this Software without prior written
    permission of MetaStuff, Ltd.  For written permission,
    please contact dom4j-info@metastuff.com.
- 
+
 4. Products derived from this Software may not be called "DOM4J"
    nor may "DOM4J" appear in their names without prior written
    permission of MetaStuff, Ltd. DOM4J is a registered
    trademark of MetaStuff, Ltd.
- 
+
 5. Due credit should be given to the DOM4J Project - https://dom4j.github.io/
- 
+
 THIS SOFTWARE IS PROVIDED BY METASTUFF, LTD. AND CONTRIBUTORS
 ``AS IS'' AND ANY EXPRESSED OR IMPLIED WARRANTIES, INCLUDING, BUT
 NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND

--- a/build.gradle
+++ b/build.gradle
@@ -72,7 +72,7 @@ publishing {
                 url = 'http://dom4j.github.io/'
                 licenses {
                     license {
-                        name = 'BSD 3-clause New License'
+                        name = 'Plexus'
                         url = 'https://github.com/dom4j/dom4j/blob/master/LICENSE'
                     }
                 }


### PR DESCRIPTION
The pom.xml states that dom4j is using the BSD-3-Clause license, but the license text does not match that statement.

The license text matches the "Plexus Classworlds License".
The SPDX identifier is "Plexus", which would be the recomended entry for the name field in the pom.

https://spdx.org/licenses/Plexus.html