### PR TITLE
fix `removeIf()` not working on BackedList

### DIFF
--- a/src/main/java/org/dom4j/tree/BackedList.java
+++ b/src/main/java/org/dom4j/tree/BackedList.java
@@ -13,6 +13,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
+import java.util.function.Predicate;
 
 /**
  * <p>
@@ -120,6 +121,19 @@ public class BackedList<T extends Node> extends ArrayList<T> {
         }
 
         return node;
+    }
+
+    @Override
+    public boolean removeIf(Predicate<? super T> filter) {
+        boolean modified = false;
+        for (Iterator<T> iter = iterator(); iter.hasNext(); ) {
+            T node = iter.next();
+            if (filter.test(node)) {
+                iter.remove();
+                modified = true;
+            }
+        }
+        return modified;
     }
 
     @Override

--- a/src/test/java/org/dom4j/BackedListTest.java
+++ b/src/test/java/org/dom4j/BackedListTest.java
@@ -94,6 +94,24 @@ public class BackedListTest extends AbstractTestCase {
         log("Element content is now: " + element.content());
         writer.write(element);
     }
+
+    public void testRemoveIf() {
+        Element rootElement = document.getRootElement();
+        Element parentElement = rootElement.addElement("element");
+        parentElement.addElement("node1");
+        parentElement.addElement("node2");
+
+        assertTrue("`removeIf()` should return true after removing at least one element",
+                   parentElement.elements().removeIf(it -> it.getName().equals("node1")));
+
+        assertEquals("Size should have been reduced to 1",
+                     1, parentElement.elements().size());
+        assertEquals("The remaining item should be \"node2\"",
+                     "node2", parentElement.elements().get(0).getName());
+
+        assertFalse("Removing an Element that does not exist should make `removeIf()` return `false`",
+                    parentElement.elements().removeIf(it -> it.getName().equals("node1")));
+    }
 }
 
 /*


### PR DESCRIPTION
This is caused by BackedList extending ArrayList which does not use the default implementation of `removeIf()` but its own optimized implementation that does not use `remove()` so changes are not reflected in the branchContent list.

I does look like this is the only "new" method with this problem.