### PR TITLE
Remove misleading no-op lines incorrectly trying to disable external entities

### DIFF
--- a/src/main/java/org/dom4j/io/SAXHelper.java
+++ b/src/main/java/org/dom4j/io/SAXHelper.java
@@ -118,10 +118,6 @@ class SAXHelper {
         SAXHelper.setParserFeature(reader, "http://xml.org/sax/features/namespaces", true);
         SAXHelper.setParserFeature(reader, "http://xml.org/sax/features/namespace-prefixes", false);
 
-        // external entites
-        SAXHelper.setParserFeature(reader, "http://xml.org/sax/properties/external-general-entities", false);
-        SAXHelper.setParserFeature(reader, "http://xml.org/sax/properties/external-parameter-entities", false);
-
         // external DTD
         SAXHelper.setParserFeature(reader,"http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
 


### PR DESCRIPTION
- Fixes #165 

As noted in https://github.com/dom4j/dom4j/issues/51#issuecomment-493759586 these lines don't do anything - they use `/properties` rather than `/features` so throw an exception: https://xerces.apache.org/xerces-j/features.html

I can't find any reference to such (incorrect) feature keys outside DOM4J.

The correctly-named XXE-secure features are only enabled via `SaxReader.createDefault()` at
https://github.com/dom4j/dom4j/blob/41b079a88790b8d5694aa6c9c738dd624a0a667b/src/main/java/org/dom4j/io/SAXReader.java#L152-L162 and require "opt-in".

These lines are rather confusing when following the code, and may mislead folks into thinking that XXE is disabled by default by the library - which I don't think they are - if you just use `new SAXReader()`.

An alternative to this PR would be to "correct" the defaults, which would be a breaking change, and make the `setFeatures` in `SAXReader.createDefault()` irrelevant, since the same thing would have been done when the reader is created. This would risk complaints such as https://github.com/dom4j/dom4j/issues/51 where loading external DTDs _was_ intentionally disabled by default. That would have the readers more "secure by default".