### PR TITLE
Always use the document factory to create attributes

### DIFF
--- a/src/main/java/org/dom4j/dom/DOMElement.java
+++ b/src/main/java/org/dom4j/dom/DOMElement.java
@@ -358,16 +358,18 @@ public class DOMElement extends DefaultElement implements org.w3c.dom.Element {
         QName qname = null;
         String name = newAttr.getLocalName();
 
+        DocumentFactory df = getDocumentFactory();
+
         if (name != null) {
             String prefix = newAttr.getPrefix();
             String uri = newAttr.getNamespaceURI();
-            qname = getDocumentFactory().createQName(name, prefix, uri);
+            qname = df.createQName(name, prefix, uri);
         } else {
             name = newAttr.getName();
-            qname = getDocumentFactory().createQName(name);
+            qname = df.createQName(name);
         }
 
-        return new DOMAttribute(qname, newAttr.getValue());
+        return df.createAttribute(this, qname, newAttr.getValue());
     }
 
     protected QName getQName(String namespace, String qualifiedName) {

--- a/src/main/java/org/dom4j/io/DOMSAXContentHandler.java
+++ b/src/main/java/org/dom4j/io/DOMSAXContentHandler.java
@@ -484,7 +484,8 @@ public class DOMSAXContentHandler extends DefaultHandler implements LexicalHandl
                 String attributeValue = attributes.getValue(i);
                 QName qName = namespaceStack.getAttributeQName(
                         attributeURI, attributeLocalName, attributeQName);
-				DOMAttribute domAttribute = new DOMAttribute(qName, attributeValue);
+                DOMAttribute domAttribute = (DOMAttribute)documentFactory
+                        .createAttribute(element, qName, attributeValue);
                 ((DOMElement)element).setAttributeNode(domAttribute);
             }
         }


### PR DESCRIPTION
DOM4J almost always uses the document factory to create attributes, except in a few places where where a specific type is instantiated. Some of those are harmless and work as intended, however in two cases it may result in the wrong type of attribute being used.